### PR TITLE
fix: GNU/Linux systems saying Error reading profiles.ini

### DIFF
--- a/auto-installers/sine-installer.js
+++ b/auto-installers/sine-installer.js
@@ -3,7 +3,7 @@ const path = require('path');
 const readline = require('readline');
 const os = require('os');
 const https = require('https');
-
+let isLiGNUx = false;
 // Create readline interface for user input
 const rl = readline.createInterface({
   input: process.stdin,
@@ -21,6 +21,7 @@ function getProfileDir() {
     case 'darwin':
       return path.join(homeDir, 'Library', 'Application Support', 'Zen', 'Profiles');
     case 'linux':
+      isLiGNUx = true;
       return path.join(homeDir, '.zen');
     default:
       throw new Error(`Unsupported platform: ${platform}`);
@@ -29,7 +30,7 @@ function getProfileDir() {
 
 // Function to parse profiles.ini and extract profile paths
 async function getProfiles(profileDir) {
-  const iniPath = path.join(profileDir, '..', 'profiles.ini');
+  const iniPath = path.join(profileDir, isLiGNUx ? '' : '..', 'profiles.ini');
   try {
     const iniContent = await fs.promises.readFile(iniPath, 'utf8');
     const profiles = [];

--- a/mods/transparent-newtab/mod.uc.js
+++ b/mods/transparent-newtab/mod.uc.js
@@ -1,5 +1,0 @@
-// ==UserScript==
-// @ignorecache
-// ==/UserScript==
-
-console.log("Transparent New Tab JS is loaded!");


### PR DESCRIPTION
the problem is, you are using `..` with `path.join` which is correct for windows and macOS. but on GNU/Linux, that will just point to `$HOME` skipping `$HOME/.zen` :))
so what i did was just add a new variable, `isLiGNUx` which is a boolean, `false` by default but if ran on GNU/Linux it will be `true`, and if the system is GNU/Linux it will not join `..` unlike Windows and macOS.

Hope it get merged :))