### PR TITLE
Add first test

### DIFF
--- a/.browsercfg.json
+++ b/.browsercfg.json
@@ -17,7 +17,9 @@
       "{remote}/bootloader/profile/utils": "{profile}/chrome/utils",
       "src": "{profile}/chrome/JS",
       "locales": "{profile}/chrome/JS/locales",
-      "engine.tmp.json": "{profile}/chrome/JS/engine.json"
+      "engine.tmp.json": "{profile}/chrome/JS/engine.json",
+      "tests": "{profile}/chrome/tests"
     }
-  }
+  },
+  "test": {}
 }

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 bunx fast-staged
+bun run test
 
 EXIT_CODE=$? # save exit code from fast-staged that gets overwritten by echo
 echo # print a newline

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,15 +2,17 @@
 
 - [ ] My code passes the `bun lint` script and all checks performed by it.
 - [ ] My code passes the `bun fmt:check` script and all checks performed by it.
-- [ ] My code obeys the [Code of Conduct](https://github.com/CosmoCreeper/Sine/tree/cosine/CODE_OF_CONDUCT.md) guidelines.
-- [ ] My code works as intended without noticeable performance effects.
+- [ ] My code obeys the [Code of Conduct](../CODE_OF_CONDUCT.md) guidelines.
+- [ ] My code works as intended in an isolated [browsercfg](../docs/browsercfg.md) instance without noticeable performance effects.
 - [ ] My code works with all pre-existing mod capabilities. <!-- It's okay if your pull request doesn't, but this is important to know. -->
 
 # AI use
+
 <!-- You may use AI, but only in appropriate contexts. -->
+
 - [ ] My pull request is programmed entirely or mostly with AI.
 - [ ] My pull request only partially uses AI. <!-- How was it used? --> \
-      **If the above is applicable, I have used AI for:** 
+       **If the above is applicable, I have used AI for:**
 - [ ] I have only used AI for documentation of Firefox APIs or similar. **No code was written with it.**
 - [ ] My pull request does not use any AI.
 
@@ -18,12 +20,13 @@
   If you find your pull request matching this checkbox's description,
   it will not be merged until that is no longer the case.
 -->
+
 - [ ] My pull request implements an AI-based feature. (e.g. chatbot)
 
 # Description
+
 <!-- Accurately and appropriately describe all major/minor fixes, improvements, and features added/changed in this pull request. -->
 
-
 # Screenshots
-<!-- Include any screenshots, if applicable. -->
 
+<!-- Include screenshots, if applicable. Otherwise, comment this out. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-# Checklist
+## Checklist
 
 - [ ] My code passes the `bun lint` script and all checks performed by it.
 - [ ] My code passes the `bun fmt:check` script and all checks performed by it.
@@ -6,7 +6,7 @@
 - [ ] My code works as intended in an isolated [browsercfg](../docs/browsercfg.md) instance without noticeable performance effects.
 - [ ] My code works with all pre-existing mod capabilities. <!-- It's okay if your pull request doesn't, but this is important to know. -->
 
-# AI use
+## AI use
 
 <!-- You may use AI, but only in appropriate contexts. -->
 
@@ -23,10 +23,10 @@
 
 - [ ] My pull request implements an AI-based feature. (e.g. chatbot)
 
-# Description
+## Description
 
 <!-- Accurately and appropriately describe all major/minor fixes, improvements, and features added/changed in this pull request. -->
 
-# Screenshots
+## Screenshots
 
 <!-- Include screenshots, if applicable. Otherwise, comment this out. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,29 @@
+# Checklist
+
+- [ ] My code passes the `bun lint` script and all checks performed by it.
+- [ ] My code passes the `bun fmt:check` script and all checks performed by it.
+- [ ] My code obeys the [Code of Conduct](https://github.com/CosmoCreeper/Sine/tree/cosine/CODE_OF_CONDUCT.md) guidelines.
+- [ ] My code works as intended without noticeable performance effects.
+- [ ] My code works with all pre-existing mod capabilities. <!-- It's okay if your pull request doesn't, but this is important to know. -->
+
+# AI use
+<!-- You may use AI, but only in appropriate contexts. -->
+- [ ] My pull request is programmed entirely or mostly with AI.
+- [ ] My pull request only partially uses AI. <!-- How was it used? --> \
+      **If the above is applicable, I have used AI for:** 
+- [ ] I have only used AI for documentation of Firefox APIs or similar. **No code was written with it.**
+- [ ] My pull request does not use any AI.
+
+<!--
+  If you find your pull request matching this checkbox's description,
+  it will not be merged until that is no longer the case.
+-->
+- [ ] My pull request implements an AI-based feature. (e.g. chatbot)
+
+# Description
+<!-- Accurately and appropriately describe all major/minor fixes, improvements, and features added/changed in this pull request. -->
+
+
+# Screenshots
+<!-- Include any screenshots, if applicable. -->
+

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -66,7 +66,7 @@ jobs:
         run: bun ci
 
       - name: Configure browser
-        run: bun select --browser zen-twilight --download
+        run: bunx browsercfg select --browser zen-twilight --download
 
       - name: Run tests
         run: bun run test

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -47,3 +47,26 @@ jobs:
 
       - name: Run zizmor
         uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
+
+  test:
+    name: Run tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun ci
+
+      - name: Configure browser
+        run: bun select --browser zen-twilight --download
+
+      - name: Run tests
+        run: bun run test

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "sine",
       "devDependencies": {
-        "@chromejs/browsercfg": "^0.1.6",
+        "@chromejs/browsercfg": "^0.1.8",
         "@eslint/js": "^10.0.1",
         "@eslint/json": "^1.2.0",
         "@microsoft/eslint-plugin-sdl": "^1.1.0",
@@ -22,23 +22,23 @@
     },
   },
   "packages": {
-    "@chromejs/browsercfg": ["@chromejs/browsercfg@0.1.6", "", { "optionalDependencies": { "@chromejs/browsercfg-darwin-arm64": "0.1.6", "@chromejs/browsercfg-darwin-x64": "0.1.6", "@chromejs/browsercfg-linux-arm64": "0.1.6", "@chromejs/browsercfg-linux-arm64-musl": "0.1.6", "@chromejs/browsercfg-linux-x64": "0.1.6", "@chromejs/browsercfg-linux-x64-musl": "0.1.6", "@chromejs/browsercfg-win32-arm64": "0.1.6", "@chromejs/browsercfg-win32-x64": "0.1.6" }, "bin": { "browsercfg": "bin/browsercfg" } }, "sha512-EqSdU4t4GOM9PT5SkNzFOKUli8+YNLnXHnc1AcaNib0jizEIjhctDntl9e4pnzFE/1BF2to9qb244+m4FETqMA=="],
+    "@chromejs/browsercfg": ["@chromejs/browsercfg@0.1.8", "", { "optionalDependencies": { "@chromejs/browsercfg-darwin-arm64": "0.1.8", "@chromejs/browsercfg-darwin-x64": "0.1.8", "@chromejs/browsercfg-linux-arm64": "0.1.8", "@chromejs/browsercfg-linux-arm64-musl": "0.1.8", "@chromejs/browsercfg-linux-x64": "0.1.8", "@chromejs/browsercfg-linux-x64-musl": "0.1.8", "@chromejs/browsercfg-win32-arm64": "0.1.8", "@chromejs/browsercfg-win32-x64": "0.1.8" }, "bin": { "browsercfg": "bin/browsercfg" } }, "sha512-R4wngZSCkSO+xyxXRZ93lENcM8vdtt864d0n5Ft7nAprs0gwdEfL1u3domHwrba5AB8Sljm8Rrt+4dBrw/vBHA=="],
 
-    "@chromejs/browsercfg-darwin-arm64": ["@chromejs/browsercfg-darwin-arm64@0.1.6", "", { "os": "darwin", "cpu": "arm64" }, "sha512-scHU3e7FITl7XRrTcpoRixil44p54PaM+M1N3/UMyn1F4wrO+mkV+cX4plQUK+sVMM6+2ghEjK8znRSR/FbfMA=="],
+    "@chromejs/browsercfg-darwin-arm64": ["@chromejs/browsercfg-darwin-arm64@0.1.8", "", { "os": "darwin", "cpu": "arm64" }, "sha512-5USB84EGCKRpK4N+KlXyksCzULfH+48+T/b1FDc02swWVwL7I8v3dhNe58OXaa5kxO+6L0wUvAs6Xpf0C5HnIQ=="],
 
-    "@chromejs/browsercfg-darwin-x64": ["@chromejs/browsercfg-darwin-x64@0.1.6", "", { "os": "darwin", "cpu": "x64" }, "sha512-NAIrLb+M6i/BEhJbtLG1j8LZUB1VWrGNPejNersaxDshFb9tKY3Lgfh7gS1zY+KAz2zxb2KYN1hRtPj7bWS37w=="],
+    "@chromejs/browsercfg-darwin-x64": ["@chromejs/browsercfg-darwin-x64@0.1.8", "", { "os": "darwin", "cpu": "x64" }, "sha512-WPuMO4xudzlz23Slg75HunP28H1GBEANOQqJ5una+Kztn0w8es7HJwpJLhnm5EUevcI2zkqpHb4GkZOc9oU2qg=="],
 
-    "@chromejs/browsercfg-linux-arm64": ["@chromejs/browsercfg-linux-arm64@0.1.6", "", { "os": "linux", "cpu": "arm64" }, "sha512-CRAXsaABRZLiqhnmFAai8bOtKKIfBAkPQkhObecqQKb4TK3S9a8kdziUBeEWrFCy7SlMYqLPrICDM163ChUr6A=="],
+    "@chromejs/browsercfg-linux-arm64": ["@chromejs/browsercfg-linux-arm64@0.1.8", "", { "os": "linux", "cpu": "arm64" }, "sha512-1F5DM1EWi6MK1L1QP8gpmJbfM9zbT2fInymPDy1xDyV6KJKbfm2Kbi73xesoAGPUa21InOTmrwJoVsLtV42tfg=="],
 
-    "@chromejs/browsercfg-linux-arm64-musl": ["@chromejs/browsercfg-linux-arm64-musl@0.1.6", "", { "os": "linux", "cpu": "arm64" }, "sha512-bW1cLKcKXIVC3IoEVmrsk2lVoy+vXXg7C+rkAvAvpAuiUCPMpbfHLPtmFXWIPKleHqHw86qwbl2jZNjPZTc56A=="],
+    "@chromejs/browsercfg-linux-arm64-musl": ["@chromejs/browsercfg-linux-arm64-musl@0.1.8", "", { "os": "linux", "cpu": "arm64" }, "sha512-vsw0xMxjGyKXL+CnRpZrbvFoDkWrulkUHfKOw66WqBFoAPpIeXi5MOs1wb0QhhhfPBSBbEBawMne0u0Za4A7Wg=="],
 
-    "@chromejs/browsercfg-linux-x64": ["@chromejs/browsercfg-linux-x64@0.1.6", "", { "os": "linux", "cpu": "x64" }, "sha512-PXXBf83XkcVx4Spb3VfdypFnnHXWm7eDmSKOfjijQSCGDFg3sAauiTMbM5CzNh1ZmioJeeTD0rJgQdWMzuK4Gg=="],
+    "@chromejs/browsercfg-linux-x64": ["@chromejs/browsercfg-linux-x64@0.1.8", "", { "os": "linux", "cpu": "x64" }, "sha512-zy/XlRbx/IUJ6q2W5RiGX2ev/YyzJt8HVm4Uh+9wSj0zZ8jxabb+hwm5gTiWS0R8UgCN62uPhcA88Ny0ILxlKQ=="],
 
-    "@chromejs/browsercfg-linux-x64-musl": ["@chromejs/browsercfg-linux-x64-musl@0.1.6", "", { "os": "linux", "cpu": "x64" }, "sha512-GS+RZIn9ZeXFqFjgJE8AcBS0izWlBH776k296OHmh+FRlpkcTF53FnckV7LWLs7vSs9YTVIFbvLPXwXCZdbxEg=="],
+    "@chromejs/browsercfg-linux-x64-musl": ["@chromejs/browsercfg-linux-x64-musl@0.1.8", "", { "os": "linux", "cpu": "x64" }, "sha512-Ny7oJNOOi7f/fQUlbgmzjc7UiUeOVbCF1gnub6PGs+a3cypncPq3fcSvo0zUGx5dp9v+KbAFe5+5QSsoArdwkg=="],
 
-    "@chromejs/browsercfg-win32-arm64": ["@chromejs/browsercfg-win32-arm64@0.1.6", "", { "os": "win32", "cpu": "arm64" }, "sha512-4enkzCImQd7dX3hi5E84hRgAjDQfa31MMABJkzkBXp5/MMwSADzBcKh8ra4HTDytlqOMqkYjy+uyGD5sCHn+DA=="],
+    "@chromejs/browsercfg-win32-arm64": ["@chromejs/browsercfg-win32-arm64@0.1.8", "", { "os": "win32", "cpu": "arm64" }, "sha512-4HDkrGwZ3uBQZ3kalu2LFsAwzHCCC4iU9XZLdYgs1as7gVPXx4OTkCiKeSY9hxjwZ6g4Ll6s46vbdotaUikgOw=="],
 
-    "@chromejs/browsercfg-win32-x64": ["@chromejs/browsercfg-win32-x64@0.1.6", "", { "os": "win32", "cpu": "x64" }, "sha512-yyBfkM/A3Zr8l/rIPeBRQ+OxvrOE7jcm7V3murW8UA2FMk5h340R4sSnPhT7LY6H7Xe/7Trqlq7acmRrrP4KeQ=="],
+    "@chromejs/browsercfg-win32-x64": ["@chromejs/browsercfg-win32-x64@0.1.8", "", { "os": "win32", "cpu": "x64" }, "sha512-kAt23theSTylg3PdiHIngboLH7HmUSS8eck3TmiHyamv3H2W7Iw/xYQHsSMHltrsVpNvW87C5h+Z3SSygwgONg=="],
 
     "@es-joy/jsdoccomment": ["@es-joy/jsdoccomment@0.86.0", "", { "dependencies": { "@types/estree": "^1.0.8", "@typescript-eslint/types": "^8.58.0", "comment-parser": "1.4.6", "esquery": "^1.7.0", "jsdoc-type-pratt-parser": "~7.2.0" } }, "sha512-ukZmRQ81WiTpDWO6D/cTBM7XbrNtutHKvAVnZN/8pldAwLoJArGOvkNyxPTBGsPjsoaQBJxlH+tE2TNA/92Qgw=="],
 

--- a/docs/browsercfg.md
+++ b/docs/browsercfg.md
@@ -1,0 +1,46 @@
+# Testing with Browsercfg
+
+[Browsercfg](https://github.com/CosmoCreeper/browsercfg) is a tool intended to help users develop and test their AutoConfig/userChrome.js projects locally. Sine uses this tool as a way to ensure that code works in isolated, unconfigured environments (to prevent features that work on edge cases). By the end of this guide, you will be capable of testing Sine with browsercfg.
+
+The first step is to install browsercfg. You can install it either via Cargo (and the crates.io registry), or via any kind of package manager that supports the npm registry. For Sine, we manage packages via [Bun](https://bun.sh), so this guide will show you how to install browsercfg via that.
+
+<!-- Use ps1 for commands as it tends to have the best syntax highlighting in GitHub markdown -->
+
+First you must install Bun if you haven't already:
+
+```ps1
+# on Linux or macOS
+curl -fsSL https://bun.sh/install | bash
+# or on Windows
+powershell -c "irm bun.sh/install.ps1 | iex"
+```
+
+Now you can simply install the necessary dependencies for Sine via Bun:
+
+```ps1
+bun install
+```
+
+Now you have browsercfg. Congrats! You can ensure this is the case with the following command:
+
+```ps1
+bun x browsercfg --version
+```
+
+The second step is to configure the web browser you want to test on. Browsercfg makes this process simple, although it currently only supports two browsers (Firefox and Zen). You can run the following command to begin an interactive method of picking your desired browser:
+
+```ps1
+bun x browsercfg select
+```
+
+After you select your browser via that command, ensure you say yes to downloading it.
+
+The third and final step is to import Sine into browsercfg:
+
+```ps1
+bun run dev
+```
+
+After running this a web browser should open up with Sine installed. Congrats!
+
+Upon changing Sine's source code, you can rerun step three to see it reflected in the isolated browser instance.

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "prepare": "git config core.hooksPath .githooks"
   },
   "devDependencies": {
-    "@chromejs/browsercfg": "^0.1.6",
+    "@chromejs/browsercfg": "^0.1.8",
     "@eslint/js": "^10.0.1",
     "@eslint/json": "^1.2.0",
     "@microsoft/eslint-plugin-sdl": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -11,9 +11,9 @@
   "author": "CosmoCreeper",
   "type": "module",
   "scripts": {
-    "import": "browsercfg import",
-    "start": "browsercfg run",
+    "dev": "browsercfg import && browsercfg run",
     "package": "uv run scripts/package.py",
+    "test": "browsercfg test",
     "lint": "oxlint && eslint",
     "lint:fix": "oxlint --write && eslint --fix",
     "fmt": "oxfmt",

--- a/tests/paths.test.js
+++ b/tests/paths.test.js
@@ -1,0 +1,5 @@
+// Ensure the chrome.manifest and path for Sine is valid
+it("Sine path exists", () => {
+  // Will fail if the path is invalid
+  ChromeUtils.importESModule("chrome://userscripts/content/sine.sys.mjs");
+});


### PR DESCRIPTION
Tests are now possible with [browsercfg](https://github.com/CosmoCreeper/browsercfg)! This pull request implements the first test (a small test that will simply ensure that sine.sys.mjs exists and that the chrome.manifest is registered properly), and implements an automated workflow for it.

This initial workflow does not support testing on every browser, and only tests on Zen Twilight as of right now. A workflow that tests on every browser will definitely take a lot longer, but it may be worth it.