### PR TITLE
feat: SHA-based store mod installation

### DIFF
--- a/src/core/manager.sys.mjs
+++ b/src/core/manager.sys.mjs
@@ -731,13 +731,15 @@ class Manager {
     const regexes = [
       /^(?:https?:\/\/)?github\.com\/([^/]+)\/([^/]+)$/u,
       /^(?:https?:\/\/)?github\.com\/([^/]+)\/([^/]+)\/tree\/([^/]+)(\/.*)?$/u,
+      /^(?:https?:\/\/)?github\.com\/([^/]+)\/([^/]+)\/commit\/([^/]+)(\/.*)?$/u,
       /^(?:https?:\/\/)?raw\.githubusercontent\.com\/([^/]+)\/([^/]+)\/refs\/heads\/([^/]+)(\/.*)?$/u,
       /^(?:https?:\/\/)?raw\.githubusercontent\.com\/([^/]+)\/([^/]+)\/([^/]+)(\/.*)?$/u,
       /^([^/]+)\/([^/]+)\/tree\/([^/]+)(\/.*)?$/u,
+      /^([^/]+)\/([^/]+)\/commit\/([^/]+)(\/.*)?$/u,
       /^([^/]+)\/([^/]+)$/u,
     ];
 
-    for (const regex of regexes) {
+    for (const [idx, regex] of regexes.entries()) {
       const match = url.match(regex);
       if (match) {
         const author = match[1];
@@ -746,7 +748,11 @@ class Manager {
         let branch = "main";
         let folder = "";
         if (match.length > 3) {
-          branch = match[3];
+          if (idx === 2 || idx === 6) {
+            branch = match[3];
+          } else {
+            branch = `refs/heads/${match[3]}`;
+          }
           folder = match[4] || "";
         }
 
@@ -818,9 +824,9 @@ class Manager {
    */
   async syncModData(repoLink, currModsList, newThemeData, currModData = false) {
     const themeFolder = utils.getModFolder(newThemeData.id);
-    const nestedPath = `main/mods/${newThemeData.id}`;
     if (repoLink === "{store}") {
-      repoLink = `sineorg/store/tree/${nestedPath}`;
+      const repoData = this.constructor.parseGitHubUrl(newThemeData.homepage);
+      repoLink = `${repoData.author}/${repoData.name}/commit/${newThemeData.commit}/${repoData.folder}`;
       newThemeData.origin = "store";
     } else if (newThemeData.origin) {
       // Prevent mods from pretending to be verified and from the store.
@@ -834,11 +840,7 @@ class Manager {
       await IOUtils.remove(themeFolder, { recursive: true });
     }
 
-    let zipUrl = `https://codeload.github.com/${repo.author}/${repo.name}/zip/refs/heads/${repo.branch}`;
-    if (newThemeData.origin === "store") {
-      repo = this.constructor.parseGitHubUrl(newThemeData.homepage);
-      zipUrl = `https://raw.githubusercontent.com/sineorg/store/${nestedPath}/mod.zip`;
-    }
+    let zipUrl = `https://codeload.github.com/${repo.author}/${repo.name}/zip/${repo.branch}`;
     const zipEntries = await ucAPI.unpackRemoteArchive({
       url: zipUrl,
       id: newThemeData.id,


### PR DESCRIPTION
## Checklist

- [x] My code passes the `bun lint` script and all checks performed by it.
- [x] My code passes the `bun fmt:check` script and all checks performed by it.
- [x] My code obeys the [Code of Conduct](../CODE_OF_CONDUCT.md) guidelines.
- [x] My code works as intended in an isolated [browsercfg](../docs/browsercfg.md) instance without noticeable performance effects.
- [x] My code works with all pre-existing mod capabilities. <!-- It's okay if your pull request doesn't, but this is important to know. -->

## AI use

<!-- You may use AI, but only in appropriate contexts. -->

- [ ] My pull request is programmed entirely or mostly with AI.
- [ ] My pull request only partially uses AI. <!-- How was it used? --> \
       **If the above is applicable, I have used AI for:**
- [ ] I have only used AI for documentation of Firefox APIs or similar. **No code was written with it.**
- [x] My pull request does not use any AI.

<!--
  If you find your pull request matching this checkbox's description,
  it will not be merged until that is no longer the case.
-->

- [ ] My pull request implements an AI-based feature. (e.g. chatbot)

## Description

<!-- Accurately and appropriately describe all major/minor fixes, improvements, and features added/changed in this pull request. -->

All mods installed from the store will now be installed using a full length commit SHA instead of our traditional zip-based method being stored on the store repository. This will cut down on repo size and cloning times (for the store specifically), while maintaining security.