### PR TITLE
fix: Switch from ownerGlobal to windowRoot

### DIFF
--- a/src/core/settings.mjs
+++ b/src/core/settings.mjs
@@ -7,7 +7,7 @@
  */
 
 import * as domUtils from "../utils/dom.mjs";
-import injectCmdPalette from "../services/cmdPalette.mjs";
+import cmdPalette from "../services/cmdPalette.mjs";
 import updates from "../services/updates.mjs";
 
 const ucAPI = ChromeUtils.importESModule(
@@ -231,13 +231,12 @@ const loadPrefs = async () => {
 
         if (pref.property === "sine.enable-dev") {
           prefEl.addEventListener("click", () => {
-            const commandPalette =
-              windowRoot.ownerGlobal.document.querySelector(".sineCommandPalette");
+            const commandPalette = windowRoot.window.document.querySelector(".sineCommandPalette");
             if (commandPalette) {
               commandPalette.remove();
             }
 
-            injectCmdPalette();
+            cmdPalette.register();
           });
         }
 

--- a/src/services/cmdPalette.mjs
+++ b/src/services/cmdPalette.mjs
@@ -24,10 +24,10 @@ export default {
       return;
     }
 
-    domUtils.injectLocale("sine-cmdpalette", windowRoot.ownerGlobal.document);
+    domUtils.injectLocale("sine-cmdpalette", windowRoot.window.document);
 
     const palette = domUtils.appendXUL(
-      windowRoot.ownerGlobal.document.body,
+      windowRoot.window.document.body,
       `
               <div class="sineCommandPalette" hidden="">
                   <div class="sineCommandInput" hidden=""></div>
@@ -132,7 +132,7 @@ export default {
       }
     });
 
-    windowRoot.ownerGlobal.document.addEventListener("keydown", (e) => {
+    windowRoot.window.document.addEventListener("keydown", (e) => {
       if (e.ctrlKey && e.shiftKey && e.key === "Y") {
         refreshCmds(options);
 
@@ -147,7 +147,7 @@ export default {
       }
     });
 
-    windowRoot.ownerGlobal.document.addEventListener("mousedown", (e) => {
+    windowRoot.window.document.addEventListener("mousedown", (e) => {
       let targetEl = e.target;
       while (targetEl) {
         if (targetEl === palette) {


### PR DESCRIPTION
## Checklist

- [x] My code passes the `bun lint` script and all checks performed by it.
- [x] My code passes the `bun fmt:check` script and all checks performed by it.
- [x] My code obeys the [Code of Conduct](../CODE_OF_CONDUCT.md) guidelines.
- [x] My code works as intended in an isolated [browsercfg](../docs/browsercfg.md) instance without noticeable performance effects.
- [x] My code works with all pre-existing mod capabilities. <!-- It's okay if your pull request doesn't, but this is important to know. -->

## AI use

<!-- You may use AI, but only in appropriate contexts. -->

- [ ] My pull request is programmed entirely or mostly with AI.
- [ ] My pull request only partially uses AI. <!-- How was it used? --> \
       **If the above is applicable, I have used AI for:**
- [ ] I have only used AI for documentation of Firefox APIs or similar. **No code was written with it.**
- [x] My pull request does not use any AI.

<!--
  If you find your pull request matching this checkbox's description,
  it will not be merged until that is no longer the case.
-->

- [ ] My pull request implements an AI-based feature. (e.g. chatbot)

## Description

<!-- Accurately and appropriately describe all major/minor fixes, improvements, and features added/changed in this pull request. -->

Resolves command palette loading and initialization by switching to a newer, reliable method of fetching the parent window global in new Firefox versions, that being `windowRoot.window`, rather than `document.ownerGlobal`. (fixes #635)