### PR TITLE
fix: untrusted mod actors not loading

### DIFF
--- a/src/services/injectAPI.sys.mjs
+++ b/src/services/injectAPI.sys.mjs
@@ -17,6 +17,7 @@ try {
         DOMContentLoaded: {},
       },
     },
+    safeForUntrustedWebProcess: true,
     matches: [
       "https://sineorg.github.io/store/*",
       "https://zen-browser.app/*",


### PR DESCRIPTION
## Checklist

- [x] My code passes the `bun lint` script and all checks performed by it.
- [x] My code passes the `bun fmt:check` script and all checks performed by it.
- [x] My code obeys the [Code of Conduct](../CODE_OF_CONDUCT.md) guidelines.
- [x] My code works as intended in an isolated [browsercfg](../docs/browsercfg.md) instance without noticeable performance effects.
- [x] My code works with all pre-existing mod capabilities. <!-- It's okay if your pull request doesn't, but this is important to know. -->

## AI use

<!-- You may use AI, but only in appropriate contexts. -->

- [ ] My pull request is programmed entirely or mostly with AI.
- [ ] My pull request only partially uses AI. <!-- How was it used? --> \
       **If the above is applicable, I have used AI for:**
- [ ] I have only used AI for documentation of Firefox APIs or similar. **No code was written with it.**
- [x] My pull request does not use any AI.

<!--
  If you find your pull request matching this checkbox's description,
  it will not be merged until that is no longer the case.
-->

- [ ] My pull request implements an AI-based feature. (e.g. chatbot)

## Description

This pull request resolves an issue with the latest v2.3.4c release where the mod actors for the Zen theme store and the Sine store do not load.
