### PR TITLE
Add Native Wayland support for Linux builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,18 +75,47 @@ jobs:
         run: |
           git clone --recurse-submodules https://github.com/sineorg/installer.git external
 
-      # ---------- Linux OpenGL / X11 ----------
-      - name: Install OpenGL dependencies (Linux)
+      # ---------- Linux OpenGL / Wayland / X11 ----------
+      - name: Install GUI dependencies (Linux)
         if: matrix.os == 'linux'
         run: |
           sudo apt-get update
           sudo apt-get install -y \
+            pkg-config \
             libgl1-mesa-dev \
+            libegl1-mesa-dev \
             libx11-dev \
             libxrandr-dev \
             libxinerama-dev \
             libxcursor-dev \
-            libxi-dev
+            libxi-dev \
+            libxext-dev \
+            libxfixes-dev \
+            libwayland-dev \
+            libwayland-bin \
+            wayland-protocols \
+            libxkbcommon-dev \
+            libxkbcommon-x11-dev \
+            extra-cmake-modules
+
+      - name: Enable Wayland feature for GLFW (Linux)
+        if: matrix.os == 'linux'
+        run: |
+          python3 -c "
+          import json
+          with open('external/vcpkg.json', 'r') as f:
+              data = json.load(f)
+          for i, dep in enumerate(data.get('dependencies', [])):
+              if dep == 'glfw3':
+                  data['dependencies'][i] = {'name': 'glfw3', 'features': ['wayland']}
+              elif isinstance(dep, dict) and dep.get('name') == 'glfw3':
+                  features = dep.get('features', [])
+                  if 'wayland' not in features:
+                      features.append('wayland')
+                  dep['features'] = features
+          with open('external/vcpkg.json', 'w') as f:
+              json.dump(data, f, indent=2)
+          "
 
       # ---------- Ninja ----------
       - name: Install Ninja (Linux)
@@ -132,8 +161,12 @@ jobs:
         run: |
           cmake -S external -B build \
             -G "${GENERATOR}" \
+            -DCMAKE_TOOLCHAIN_FILE="${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake" \
+            -DVCPKG_TARGET_TRIPLET="${VCPKG_DEFAULT_TRIPLET}" \
             -DSINE_VERSION=${SINE_VERSION} \
-            -DBOOT_VERSION=${BOOT_VERSION}
+            -DBOOT_VERSION=${BOOT_VERSION} \
+            -DGLFW_BUILD_WAYLAND=ON \
+            -DGLFW_BUILD_X11=ON
         env:
           VCPKG_ROOT: ${{ github.workspace }}/vcpkg
           VCPKG_DEFAULT_TRIPLET: ${{ matrix.triplet }}


### PR DESCRIPTION
## Checklist

- [x] My code passes the `bun lint` script and all checks performed by it.
- [x] My code passes the `bun fmt:check` script and all checks performed by it.
- [x] My code obeys the [Code of Conduct](../CODE_OF_CONDUCT.md) guidelines.
- [x] My code works as intended in an isolated [browsercfg](../docs/browsercfg.md) instance without noticeable performance effects.
- [x] My code works with all pre-existing mod capabilities. <!-- It's okay if your pull request doesn't, but this is important to know. -->

## AI use

<!-- You may use AI, but only in appropriate contexts. -->

- [x] My pull request is programmed entirely or mostly with AI. But tested thoroughly in Hyprland for the auto-detection of wayland/x11 modes

<!--
  If you find your pull request matching this checkbox's description,
  it will not be merged until that is no longer the case.
-->

## Description

<!-- Accurately and appropriately describe all major/minor fixes, improvements, and features added/changed in this pull request. -->
This PR adds wayland support for linux builds and such that the builds auto-detect if the system is in `wayland` or `x11` mode

## Screenshots

<!-- Include screenshots, if applicable. Otherwise, comment this out. -->
<img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/23d18c07-4f35-4378-87ea-5fa0f350cc45" />
